### PR TITLE
[fix] gwcで未コミットのworktreeを削除対象から除外

### DIFF
--- a/bash/alias.bash
+++ b/bash/alias.bash
@@ -81,6 +81,8 @@ git-default-branch() {
 #   "* " カレントworktreeでチェックアウト中 (削除対象から除外)
 #   "+ " 別worktreeでチェックアウト中         (削除対象 — 本関数のメイン用途)
 #   "  " どこにもチェックアウトされていない    (削除対象)
+# ガード: reflogが1件以下 (= ブランチ作成後に一度もコミットしていない) は削除しない
+#        base が進んだ後でも「自分で何か積んだか」を正しく判定できる
 gwc() {
   local base flag="-d"
   if [[ "$1" == "-f" ]]; then
@@ -94,6 +96,13 @@ gwc() {
     | grep -v '^\*' \
     | sed 's/^[+ ] //' \
     | grep -vE "^($base)$" \
+    | while read -r br; do
+        if (( $(git reflog show "$br" 2>/dev/null | wc -l) <= 1 )); then
+          echo "gwc: skip '$br' (コミット履歴なし)" >&2
+        else
+          printf '%s\n' "$br"
+        fi
+      done \
     | xargs -r -I{} git wt "$flag" {}
 }
 #---------------------------------------


### PR DESCRIPTION
## 背景

`gwc` は「デフォルトブランチにマージ済の worktree を一括削除する」ためのヘルパーだが、`git branch --merged <base>` は **tip が base から到達可能であれば含める** というだけの判定なので、**1 コミットもしていない新規ブランチ** も巻き込まれてしまっていた。

`git worktree add -b feature main` 直後のような「まだ何もコミットしていない」ブランチを、ユーザーの意思と無関係に消してしまう可能性があった。

## 修正内容

`git reflog show <branch>` のエントリ数が **1 以下** なら削除対象から除外するガードを追加。

- 新規作成直後のブランチは reflog が 1 件 (\`branch: Created from ...\`) のみ
- 自分でコミットを積むと 2 件以上になる
- tip の SHA 比較ではなく reflog で見ているので、**base が進行した後の stale な 0コミットブランチ** (tip が現在の base と一致しなくなっているケース) も正しく保護できる

## ブランチ状態ごとの挙動

base = \`main\`, worktree = \`feature\` の前提で、論理的に存在しうる 6 ケース (コミット無しの場合は「main にマージ済」があり得ないので 8 通りから 2 通り除外) それぞれの挙動:

| ケース | 自分のコミット | mainにマージ済 | 未コミット変更 | \`gwc\` (安全) | \`gwc -f\` (強制) |
|---|---|---|---|---|---|
| **A** | ✓ | ✗ | ✗ | 残る (未マージなので \`--merged\` に入らない) | 残る |
| **B** | ✓ | ✗ | ✓ | 残る (同上) | 残る |
| **C** | ✓ | ✓ | ✗ | **消える** ✓ (本来の削除対象) | 消える |
| **D** | ✓ | ✓ | ✓ | 残る (dirty で \`git wt -d\` がエラー) | 消える |
| **E** | ✗ | — | ✗ | 残る (**本 PR のガード**で skip) | 残る |
| **F** | ✗ | — | ✓ | 残る (**本 PR のガード**で skip) | 残る |

※ \`gitignore\` 対象のファイルのみ変更がある場合は \`git status\` 上 clean 扱いなので C と同じ挙動 (削除される)。

## 実験結果

\`mktemp\` で作った使い捨て repo に A〜F + stale-fresh (base 進行後も残っている 0コミットブランチ) を仕込んで検証:

\`\`\`
gwc: skip 'fresh-after' (コミット履歴なし)
gwc: skip 'stale-fresh' (コミット履歴なし)
Deleted branch verify-committed (was a92af2a).
Deleted worktree ".../verify-committed" and branch "verify-committed"
\`\`\`

\`-f\` かつ untracked ファイルありでもガードは突破されないことも確認済み。

## 既知の限界 (本 PR では対応しない)

- **Squash merge / Rebase merge** されたブランチは tip が main から到達不能なので \`--merged\` に入らず、C/D の想定でも残る。対策には \`gh poi\` (既存エイリアス \`gpoi\`) 等の併用が必要。
- \`core.logallrefupdates=false\` で reflog が無効だとガードの判定が conservative 側に倒れ、結果としてマージ済ブランチも skip される。事故にはならないがデフォルト運用では問題にならない想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)